### PR TITLE
Export icon paths for prototypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 
+### New features
+
+- Factorio Exporter can now export icon paths for prototypes.
+
+### Incompatible changes
+
+- To avoid double parsing, `FactorioExporter::export` now returns a
+  `serde_yaml::Value` instead of a `String`.
+
 ## [0.1.2] - 2022-11-01
 
 ## [0.1.1] - 2022-11-01

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ required-features = ["clap", "tracing-subscriber"]
 
 [dependencies]
 clap = { version = "4.0.18", optional = true, features = ["derive"] }
+convert_case = "0.6.0"
 derive_builder = "0.11.2"
 indoc = "1.0.7"
 itertools = "0.10.5"

--- a/lua/instrument-after-data.lua
+++ b/lua/instrument-after-data.lua
@@ -1,0 +1,21 @@
+export = require "export"
+
+local function ExportIcon(section, name, path)
+    export.Export("- section: ", section)
+    export.Export("  name: ", name)
+    export.Export("  path: '", path, "'")
+end
+
+export.Export("<ICONS>")
+
+for section, elements in pairs(data.raw) do
+    for _, el in pairs(elements) do
+        if el.icon then
+            ExportIcon(section, el.name, el.icon)
+        elseif el.icons and el.icons[1] then
+            ExportIcon(section, el.name, el.icons[1].icon)
+        end
+    end
+end
+
+export.Export("</ICONS>")

--- a/src/bin/factorio_exporter.rs
+++ b/src/bin/factorio_exporter.rs
@@ -21,6 +21,10 @@ struct Args {
     /// Format of the output
     #[arg(long, short, default_value = "json")]
     format: OutputFormat,
+
+    /// Export icon paths
+    #[arg(long, short)]
+    icons: bool,
 }
 
 #[derive(Clone, Debug, ValueEnum)]
@@ -35,11 +39,11 @@ fn main() -> Result<()> {
     debug!("Parsed arguments: {:?}", args);
 
     let api = load_api(&args.factorio_dir)?;
-    let exporter = FactorioExporter::new(&args.factorio_dir, &api, "en")?;
+    let exporter = FactorioExporter::new(&args.factorio_dir, &api, "en", args.icons)?;
 
     match exporter.export() {
         Ok(prototypes) => {
-            let parsed: Value = serde_yaml::from_str(&prototypes)?;
+            let parsed: Value = serde_yaml::from_value(prototypes)?;
 
             let output = match args.format {
                 OutputFormat::Json => serde_json::to_string_pretty(&parsed)?,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,8 @@ pub enum FactorioExporterError {
     YamlParsingError(#[from] serde_yaml::Error),
     #[error("error while executing Factorio")]
     FactorioExecutionError { stdout: String, stderr: String },
+    #[error("failed to parse Factorio output")]
+    FactorioOutputError { message: String, output: String },
 }
 
 pub type Result<T> = std::result::Result<T, FactorioExporterError>;


### PR DESCRIPTION
Icon paths are not available in Factorio's runtime stage, so we must
resort to getting them in the data stage. Unfortunately data structures
in the data stage are a bit messy, so we need to apply some heuristics
to map icons into the prototypes that we get in the runtime stage. We
add an icon property to a prototype if it's `name` and `object_name` or
`type` match the section names and section element names in `data.raw`.

*Incompatible change:* To avoid double parsing,
`FactorioExporter::export` now returns a `serde_yaml::Value` instead of
a `String`.
