### PR TITLE
Add new command line options for factorio paths.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,23 @@
   "markdownlint.config": {
     "commands-show-output": false,
     "no-duplicate-header": false
-  }
+  },
+  "cSpell.enabled": true,
+  "cSpell.words": [
+    "BINPATH",
+    "canonicalize",
+    "factorio",
+    "indoc",
+    "itertools",
+    "Localised",
+    "MSRV",
+    "pastable",
+    "printdoc",
+    "rustfmt",
+    "serde",
+    "tempdir",
+    "tempfile",
+    "thiserror",
+    "writedoc"
+  ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 
+### New features
+
+- It is now possible to specify the location of the API spec and the Factorio
+  binary individually, using the new command line options `--factorio-api-spec`
+  and `--factorio-binary`. If both of them are specified, no factorio directory
+  needs to be specified
+
+### Incompatible changes
+
+- The positional command line argument for the factorio directory has been
+  replaced with a new option `--factorio_dir`. It is optional if both of
+  `--factorio-api-spec` and `--factorio-binary` are specified.
+
 ## [0.3.0] - 2022-11-03
 
 ### New features

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ See crate page on [crates.io](https://crates.io/crates/factorio-exporter)
 ## Example invocation
 
 ```sh
-$ factorio_exporter ~/tmp/factorio-full -f json | jq '.recipe_prototypes["iron-plate"]'
+$ factorio_exporter --factorio-dir ~/tmp/factorio-full -f json | jq '.recipe_prototypes["iron-plate"]'
 ```
 
 Output:
@@ -65,18 +65,41 @@ Output:
 $ factorio_exporter --help
 Exports prototypes from Factorio in JSON or YAML format
 
-Usage: factorio_exporter [OPTIONS] <FACTORIO_DIR> [MODS]...
+Usage: factorio_exporter [OPTIONS] [MODS]...
 
 Arguments:
-  <FACTORIO_DIR>  Directory where Factorio is installed. This needs to be the full version. Neither the demo nor the headless version are sufficient
-  [MODS]...       Mods to install before exporting the prototypes
+  [MODS]...
+          Mods to install before exporting the prototypes
 
 Options:
-  -d, --destination <DESTINATION>  Path where the result should be written. Uses STDOUT if not specified
-  -f, --format <FORMAT>            Format of the output [default: json] [possible values: json, yaml]
-  -i, --icons                      Export icon paths
-  -h, --help                       Print help information
-  -V, --version                    Print version information
+      --factorio-dir <FACTORIO_DIR>
+          Directory where Factorio is installed. This needs to be the full version. Neither the demo nor the headless version are sufficient. This argument is optional if both of `--factorio-api-spec` and `--factorio-binary` are specified
+
+      --factorio-api-spec <FACTORIO_API_SPEC>
+          Location of the `runtime-api.json` file. Defaults to `<FACTORIO_DIR>/doc-html/runtime-api.json`
+
+          The spec can be found in the `doc-html` directory of a full Factorio installation, or [online](https://lua-api.factorio.com/latest/runtime-api.json).
+
+      --factorio-binary <FACTORIO_BINARY>
+          Location of the factorio binary. Defaults to `<FACTORIO_DIR>/bin/x64/factorio(.exe)`. This can be any Factorio binary (full, headless, demo)
+
+  -d, --destination <DESTINATION>
+          Path where the result should be written. Uses STDOUT if not specified
+
+  -f, --format <FORMAT>
+          Format of the output
+
+          [default: json]
+          [possible values: json, yaml]
+
+  -i, --icons
+          Export icon paths
+
+  -h, --help
+          Print help information (use `-h` for a summary)
+
+  -V, --version
+          Print version information
 ```
 
 ## Library
@@ -105,6 +128,11 @@ definition of the prototypes. It tries to achieve that goal by two design decisi
 
 Another consequence of this design is that it allows to export the
 prototypes of loaded mods.
+
+## Platform support
+
+This library is intended to be platform-independent, but it's currently only
+tested on Linux.
 
 ## Contributing
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -5,17 +5,19 @@ use semver::Version;
 use serde_derive::Deserialize;
 use tracing::debug;
 
-use crate::Result;
+use crate::{FactorioExporterError, Result};
 
-const RUNTIME_API_DEFINITION: &str = "doc-html/runtime-api.json";
-
-pub fn load_api(factorio_dir: &Path) -> Result<Api> {
-    let api_file_path = factorio_dir.join(RUNTIME_API_DEFINITION);
-
+pub fn load_api(api_file_path: &Path) -> Result<Api> {
     debug!(
         "Loading API definition file from {}",
         &api_file_path.display()
     );
+
+    if !api_file_path.is_file() {
+        return Err(FactorioExporterError::FileNotFoundError {
+            file: api_file_path.into(),
+        });
+    }
 
     let s = fs::read_to_string(api_file_path)?;
     let api: Api = serde_json::from_str(&s)?;

--- a/src/bin/factorio_exporter.rs
+++ b/src/bin/factorio_exporter.rs
@@ -11,10 +11,28 @@ use tracing::{debug, info};
 #[command(version)]
 struct Args {
     /// Directory where Factorio is installed. This needs to be the full
-    /// version. Neither the demo nor the headless version are sufficient
-    factorio_dir: PathBuf,
+    /// version. Neither the demo nor the headless version are sufficient. This
+    /// argument is optional if both of `--factorio-api-spec` and
+    /// `--factorio-binary` are specified.
+    #[arg(long)]
+    factorio_dir: Option<PathBuf>,
 
-    /// Path where the result should be written. Uses STDOUT if not specified
+    /// Location of the `runtime-api.json` file. Defaults to
+    /// `<FACTORIO_DIR>/doc-html/runtime-api.json`.
+    ///
+    /// The spec can be found in the `doc-html` directory of a full Factorio
+    /// installation, or
+    /// [online](https://lua-api.factorio.com/latest/runtime-api.json).
+    #[arg(long)]
+    factorio_api_spec: Option<PathBuf>,
+
+    /// Location of the factorio binary. Defaults to
+    /// `<FACTORIO_DIR>/bin/x64/factorio(.exe)`. This can be any Factorio binary
+    /// (full, headless, demo).
+    #[arg(long)]
+    factorio_binary: Option<PathBuf>,
+
+    /// Path where the result should be written. Uses STDOUT if not specified.
     #[arg(long, short)]
     destination: Option<PathBuf>,
 
@@ -37,12 +55,47 @@ enum OutputFormat {
     Yaml,
 }
 
+/// The JSON spec of the Factorio mod API, relative to the root directory of a
+/// full Factorio installation.
+const RUNTIME_API_DEFINITION: &str = "doc-html/runtime-api.json";
+
+/// The path of the Factorio binary, relative to the root directory of a
+/// Factorio installation (either full, headless or demo).
+#[cfg(windows)]
+const FACTORIO_BINPATH: &str = "bin/x64/factorio.exe";
+#[cfg(not(windows))]
+const FACTORIO_BINPATH: &str = "bin/x64/factorio";
+
 fn main() -> Result<()> {
     let args = Args::parse();
     debug!("Parsed arguments: {:?}", args);
 
-    let api = load_api(&args.factorio_dir)?;
-    let exporter = FactorioExporter::new(&args.factorio_dir, &api, "en", args.icons)?;
+    let api_spec = std::fs::canonicalize(
+        args.factorio_api_spec
+            .or_else(|| {
+                args.factorio_dir
+                    .as_ref()
+                    .map(|d| d.join(RUNTIME_API_DEFINITION))
+            })
+            .ok_or_else(|| {
+                FactorioExporterError::InvocationError(
+                    "One of --factorio-api-spec or --factorio-dir must be specified".into(),
+                )
+            })?,
+    )?;
+
+    let binary = std::fs::canonicalize(
+        args.factorio_binary
+            .or_else(|| args.factorio_dir.as_ref().map(|d| d.join(FACTORIO_BINPATH)))
+            .ok_or_else(|| {
+                FactorioExporterError::InvocationError(
+                    "One of --factorio-binary or --factorio-dir must be specified".into(),
+                )
+            })?,
+    )?;
+
+    let api = load_api(&api_spec)?;
+    let exporter = FactorioExporter::new(&binary, &api, "en", args.icons)?;
 
     exporter.install_mods(&args.mods)?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,8 @@ pub enum FactorioExporterError {
     FactorioOutputError { message: String, output: String },
     #[error("{file} does not exist or isn't a file")]
     FileNotFoundError { file: PathBuf },
+    #[error("{0}")]
+    InvocationError(String),
 }
 
 pub type Result<T> = std::result::Result<T, FactorioExporterError>;


### PR DESCRIPTION
`--factorio-dir <FACTORIO_DIR>` Directory where Factorio is installed.
    This needs to be the full version. Neither the demo nor the headless
    version are sufficient. This argument is optional if both of
    `--factorio-api-spec` and `--factorio-binary` are specified

`--factorio-api-spec <FACTORIO_API_SPEC>` Location of the
    `runtime-api.json` file. Defaults to
    `<FACTORIO_DIR>/doc-html/runtime-api.json` The spec can be found in
    the `doc-html` directory of a full Factorio installation, or
    [online](https://lua-api.factorio.com/latest/runtime-api.json).

`--factorio-binary <FACTORIO_BINARY>` Location of the factorio binary.
    Defaults to `<FACTORIO_DIR>/bin/x64/factorio(.exe)`. This can be any
    Factorio binary (full, headless, demo)